### PR TITLE
Changes link for syslinux_url in script to stop it hanging.

### DIFF
--- a/makeUSB.sh
+++ b/makeUSB.sh
@@ -306,7 +306,7 @@ fi
     || cleanUp 10
 
 # Download memdisk
-syslinux_url='https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.gz'
+syslinux_url='https://mirrors.edge.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.gz'
 { wget -qO - "$syslinux_url" 2>/dev/null || curl -sL "$syslinux_url" 2>/dev/null; } \
     | tar -xz -C "${data_mnt}/${data_subdir}"/grub*/ --no-same-owner --strip-components 3 \
     'syslinux-6.03/bios/memdisk/memdisk' \


### PR DESCRIPTION
Although the old link did work and download the file when put into a web browser, it did not work in the script for some reason. When the script got to this step, it simply hang and didn't download the file or continue. The new link now works in the script.