### PR TITLE
fix link to git clone inside makeUSB.sh

### DIFF
--- a/makeUSB.sh
+++ b/makeUSB.sh
@@ -287,7 +287,7 @@ mkdir -p "${data_mnt}/${data_subdir}/isos" || cleanUp 10
 if [ "$clone" -eq 1 ]; then
 	# Clone Git repository
 	(cd "$repo_dir" && \
-		git clone https://github.com/aguslr/multibootusb . && \
+		git clone https://github.com/hackerncoder/multibootusb . && \
 		# Move all visible and hidden files and folders except '.' and '..'
 		for x in * .[!.]* ..?*; do if [ -e "$x" ]; then mv -- "$x" \
 			"${data_mnt}/${data_subdir}"/grub*/; fi; done) \


### PR DESCRIPTION
changed a git clone link inside makeUSB.sh to  point to hackerncoder's repository iunstead of aguslr's