### PR TITLE
use more general conf for archlinux

### DIFF
--- a/mbusb.d/archlinux.d/generic64.cfg
+++ b/mbusb.d/archlinux.d/generic64.cfg
@@ -6,8 +6,8 @@ for isofile in $isopath/archlinux-*-x86_64.iso; do
       loopback loop "$iso_path"
       menuentry "Arch Linux (x86_64)" {
         bootoptions="img_dev=$imgdevpath img_loop=$iso_path earlymodules=loop"
-        linux (loop)/arch/boot/x86_64/vmlinuz-linux $bootoptions
-        initrd (loop)/arch/boot/x86_64/archiso.img
+        linux (loop)/arch/boot/x86_64/vmlinuz* $bootoptions
+        initrd (loop)/arch/boot/x86_64/*.img
       }
     }
   fi


### PR DESCRIPTION
This change allows to boot into all available Arch Linux x86_64 ISOs: 
- all versions from archlinux-2017.04.01-x86_64.iso to ~2020 (vmlinuz, archiso.img)
- archlinux-2020.09.01-x86_64.iso (vmlinuz-linux, archiso.img)
- archlinux-2020.10.01-x86_64.iso (vmlinuz-linux, initramfs-linux.img)