### PR TITLE
Docs: add instructions for testing UEFI boot in QEMU

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -128,13 +128,26 @@ Once you have a bootable USB drive, it only remains to copy the bootable files (
 
 ## Testing USB drive with QEMU
 
-To test the newly created USB drive in a virtual environment with [QEMU][], run:
+[QEMU][] provides a virtual environment capable of booting directly from the newly created USB drive.
+
+In most installations, the **Legacy PC BIOS** mode will work by default with no additional setup, run:
 
 ```
-qemu-system-x86_64 -enable-kvm -rtc base=localtime -m 2G -vga std -drive file=<device>,readonly,cache=none,format=raw,if=virtio
+qemu-system-x86_64 -enable-kvm \
+  -rtc base=localtime -m 1G -vga std \
+  -drive file=<device>,readonly,cache=none,format=raw,if=virtio
 ```
 
-Where `<device>` is the name of the USB device (e.g. */dev/sdh*). Run `mount` to get this information.
+Testing **UEFI** boot mode is also possible with an additional firmware
+called [Tianocore OVMF][tianocore-ovmf] (not included with QEMU):
+
+```
+qemu-system-x86_64 -bios /usr/share/ovmf/x64/OVMF.fd \
+  -rtc base=localtime -m 1G -vga std \
+  -drive file=<device>,readonly,cache=none,format=raw,if=virtio
+```
+
+As usual, substitute `<device>` with the name of the USB device (e.g. */dev/sdh*).
 
 
 ## Resources
@@ -167,4 +180,5 @@ Where `<device>` is the name of the USB device (e.g. */dev/sdh*). Run `mount` to
 [qemu]: http://qemu.org/
 [qemudocs]: https://qemu.weilnetz.de/doc/qemu-doc.html
 [sgdisk]: http://www.rodsbooks.com/gdisk/sgdisk.html
+[tianocore-ovmf]: https://github.com/tianocore/edk2/blob/master/OvmfPkg/README
 [usingmemdisk]: https://wiki.archlinux.org/index.php/Multiboot_USB_drive#Using_Syslinux_and_memdisk


### PR DESCRIPTION
Hi!

Thanks for adopting this nice project and continuing to maintain it.

I've seen quite a few of those images which boot just fine in "legacy" BIOS'es, but fail in UEFI, and vice versa.

I'll also say that it's pretty cool that `multibootusb` supports `--hybrid --efi` that mostly Just Works!

But it took me a while to figure out the QEMU+UEFI combo (mostly due to confusion stemming from blindly trusting the quality of stuff in AUR)... Posting this as a doc-patch to not have to rediscover it again; also to highlight to project users that the two boot modes 1) exist 2) can both be tested in QEMU.

I've also split the long commandlines for easier comprehension.

Please let me know if LGTY, I'm hoping for an easy merge.

Thanks again, and best wishes!