### PR TITLE
Update arch-based.cfg for name change

### DIFF
--- a/mbusb.d/systemrescuecd.d/arch-based.cfg
+++ b/mbusb.d/systemrescuecd.d/arch-based.cfg
@@ -1,4 +1,4 @@
-for isofile in $isopath/systemrescuecd-*.iso; do
+for isofile in $isopath/systemrescue*.iso; do
   if [ -e "$isofile" ]; then
     # Skip old ISOs
     if regexp "x86" "$isofile"; then continue; fi


### PR DESCRIPTION
As of version 7.00 from 2020-10-17 they changed the name from systemrescuecd to systemrescue.
With this change it finds ISOs with both names.
https://www.system-rescue.org/Changes-x86/