### PR TITLE
Create netinst-generic.cfg for Debian

### DIFF
--- a/mbusb.d/debian.d/netinst-generic.cfg
+++ b/mbusb.d/debian.d/netinst-generic.cfg
@@ -1,0 +1,45 @@
+for isofile in $isopath/debian-*netinst.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname ->" "$isofile" {
+      iso_path="$2"
+      #export iso_path
+      #search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      #shared/enter_device=/dev/disk/by-label/MULTIBOOT"
+      isoptions="iso-scan/ask_second_pass=true shared/ask_device=manual shared/enter_device=$imgdevpath"
+      menuentry "Graphical install" {
+        #iso-scan/filename=$iso_path <- only checks top level dirs
+        bootoptions="vga=788 quiet"
+        linux (loop)/install.amd/vmlinuz $isoptions $bootoptions
+        #linux $isopath/debian11Vmlinuz $isoptions $bootoptions
+        initrd $isopath/debian11GtkInitrd.gz
+      }
+      menuentry "Install" {
+        bootoptions="vga=788 --- quiet"
+        linux (loop)/install.amd/vmlinuz $isoptions $bootoptions
+        initrd $isopath/debian11Initrd.gz
+      }
+      menuentry "Graphical expert install" {
+        bootoptions="priority=low vga=788"
+        linux (loop)/install.amd/vmlinuz $isoptions $bootoptions
+        initrd $isopath/debian11GtkInitrd.gz
+      }
+      menuentry "Expert install" {
+        bootoptions="priority=low vga=788 ---"
+        linux (loop)/install.amd/vmlinuz $isoptions $bootoptions
+        initrd $isopath/debian11Initrd.gz
+      }
+      menuentry "Graphical rescue mode" {
+        bootoptions="vga=788 rescue/enable=true --- quiet"
+        linux (loop)/install.amd/vmlinuz $bootoptions
+        initrd $isopath/debian11GtkInitrd.gz
+      }
+      menuentry "Rescue mode" {
+        bootoptions="vga=788 rescue/enable=true --- quiet"
+        linux (loop)/install.amd/vmlinuz $bootoptions
+        initrd $isopath/debian11Initrd.gz
+      }
+    }
+  fi
+done


### PR DESCRIPTION
Hello.
First time trying to commit.

I'd like to propose configuration file for Debian net-installer in general.
I do think this could be less practical than other distros' cases due to what I expose following this; but even so, I hope this could serve even if for some "additional notes" if not good enough for merge.

The net-installers, just like the previous CD/DVD installers (they no longer offer them in their downloads page), have always suffered of this issue:
https://wiki.debian.org/Installation+Archive+USBStick#Using_GRUB.27s_Loopback_Facility
In short, an everlasting bug from many years ago already, and which they never wanted to fix for some reason.

So one needs to use these hd-media kernel and initrd; or at least just the initrd, because I confirmed that ISO's kernel can be used indeed.
One can get them from here:
https://deb.debian.org/debian/dists/stable/main/installer-amd64/current/images/hd-media/
Then put them in Multiboot USB's corresponding location.

Now, to make it work, another user realized that still some changes in boot parameters were needed:
https://lists.debian.org/debian-user/2019/11/msg00670.html

Based on all of this, I tried making a cfg file and tested it. Surprisingly, it works.
Well, if you ignore the fact that Debian installer will always ask what ISO to use for installation if it detects more than one valid ISO in the partition, instead of there being a way to automatically select it (because as far as I searched there is not), it works quite well overall.

Seemingly the only difference with previous Debian releases is that, in the "bootoptions" for the Install menuentries, they used to begin with option "desktop=xfce". Now this is no longer the case.

Also, just as a side note, the current netboot cfg file still works. Netboot (mini) ISOs can be obtained from here:
https://deb.debian.org/debian/dists/stable/main/installer-amd64/current/images/netboot/

Thanks.