### PR TITLE
Create generic2.cfg for Slitaz

### DIFF
--- a/mbusb.d/slitaz.d/generic2.cfg
+++ b/mbusb.d/slitaz.d/generic2.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/slitaz*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    menuentry "$isoname" "$isofile" {
+      iso_path="$2"
+      #export iso_path
+      #search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      bootoptions="video=-32 autologin lang=en_US kmap=en tz=America/New_York"
+      linux (loop)/boot/bzImage $bootoptions
+      initrd (loop)/boot/rootfs4.gz (loop)/boot/rootfs3.gz (loop)/boot/rootfs2.gz (loop)/boot/rootfs1.gz
+    }
+  fi
+done


### PR DESCRIPTION
Previous cfg with memdisk doesn't seem to work anymore.

This proposed one still works; just change language, keyboard and time zone to one's corresponding options.