### PR TITLE
Change gentoo kernel location

### DIFF
--- a/mbusb.d/gentoo.d/generic.cfg
+++ b/mbusb.d/gentoo.d/generic.cfg
@@ -8,13 +8,13 @@ for isofile in $isopath/gentoo-*.iso; do
       loopback loop "$iso_path"
       menuentry "gentoo" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap looptype=squashfs loop=/image.squashfs cdroot vga=791"
-        linux (loop)/isolinux/gentoo $bootoptions
-        initrd (loop)/isolinux/gentoo.igz
+        linux (loop)/boot/gentoo $bootoptions
+        initrd (loop)/boot/gentoo.igz
       }
       menuentry "gentoo-nofb" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap looptype=squashfs loop=/image.squashfs cdroot"
-        linux (loop)/isolinux/gentoo $bootoptions
-        initrd (loop)/isolinux/gentoo.igz
+        linux (loop)/boot/gentoo $bootoptions
+        initrd (loop)/boot/gentoo.igz
       }
     }
   fi

--- a/mbusb.d/gentoo.d/livedvd-generic64.cfg
+++ b/mbusb.d/gentoo.d/livedvd-generic64.cfg
@@ -6,13 +6,13 @@ for isofile in $isopath/gentoo-livedvd-amd64-multilib-*.iso; do
       loopback loop "$iso_path"
       menuentry "Gentoo x86_64" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot console=tty1"
-        linux (loop)/isolinux/gentoo $bootoptions
-        initrd (loop)/isolinux/gentoo.xz
+        linux (loop)/boot/gentoo $bootoptions
+        initrd (loop)/boot/gentoo.xz
       }
       menuentry "Gentoo x86_64 nofb" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot nomodeset"
-        linux (loop)/isolinux/gentoo $bootoptions
-        initrd (loop)/isolinux/gentoo.xz
+        linux (loop)/boot/gentoo $bootoptions
+        initrd (loop)/boot/gentoo.xz
       }
       menuentry "Memory testing utility - memtest86+" {
         bootoptions=""

--- a/mbusb.d/gentoo.d/livedvd-generic96.cfg
+++ b/mbusb.d/gentoo.d/livedvd-generic96.cfg
@@ -6,23 +6,23 @@ for isofile in $isopath/gentoo-livedvd-x86-amd64-32ul-*.iso; do
       loopback loop "$iso_path"
       menuentry "Gentoo x86" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot console=tty1"
-        linux (loop)/isolinux/gentoo $bootoptions
-        initrd (loop)/isolinux/gentoo.xz
+        linux (loop)/boot/gentoo $bootoptions
+        initrd (loop)/boot/gentoo.xz
       }
       menuentry "Gentoo x86 nofb" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot nomodeset"
-        linux (loop)/isolinux/gentoo $bootoptions
-        initrd (loop)/isolinux/gentoo.xz
+        linux (loop)/boot/gentoo $bootoptions
+        initrd (loop)/boot/gentoo.xz
       }
       menuentry "Gentoo x86 amd64" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot console=tty1"
-        linux (loop)/isolinux/gentoo64 $bootoptions
-        initrd (loop)/isolinux/gentoo64.xz
+        linux (loop)/boot/gentoo64 $bootoptions
+        initrd (loop)/boot/gentoo64.xz
       }
       menuentry "Gentoo x86 amd64 nofb" {
         bootoptions="isoboot=$iso_path root=/dev/ram0 init=/linuxrc dokeymap aufs looptype=squashfs loop=/image.squashfs cdroot nomodeset"
-        linux (loop)/isolinux/gentoo64 $bootoptions
-        initrd (loop)/isolinux/gentoo64.xz
+        linux (loop)/boot/gentoo64 $bootoptions
+        initrd (loop)/boot/gentoo64.xz
       }
       menuentry "Memory testing utility - memtest86+" {
         bootoptions=""


### PR DESCRIPTION
The location of kernels have changed:
```/isolinux -> /boot```

[The latest gentoo image](https://www.gentoo.org/downloads/)