### PR TITLE
Update install-generic.cfg for Fedora

### DIFF
--- a/mbusb.d/fedora.d/install-generic.cfg
+++ b/mbusb.d/fedora.d/install-generic.cfg
@@ -5,32 +5,32 @@ for isofile in $isopath/Fedora-*.iso; do
     if regexp "Live" "$isofile"; then continue; fi
     submenu "$isoname ->" "$isofile" {
       iso_path="$2"
-      _loopback loop "$iso_path"
+      loopback loop "$iso_path"
       probe --label --set=cd_label (loop)
       menuentry "Install Fedora" {
         bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label quiet"
-        linux (loop)/isolinux/vmlinuz $bootoptions
-        initrd (loop)/isolinux/initrd.img
+        linux (loop)/images/pxeboot/vmlinuz $bootoptions
+        initrd (loop)/images/pxeboot/initrd.img
       }
       menuentry "Test this media & install Fedora" {
         bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label rd.live.check quiet"
-        linux (loop)/isolinux/vmlinuz $bootoptions
-        initrd (loop)/isolinux/initrd.img
+        linux (loop)/images/pxeboot/vmlinuz $bootoptions
+        initrd (loop)/images/pxeboot/initrd.img
       }
       menuentry "Install Fedora in basic graphics mode" {
         bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label nomodeset quiet"
-        linux (loop)/isolinux/vmlinuz $bootoptions
-        initrd (loop)/isolinux/initrd.img
+        linux (loop)/images/pxeboot/vmlinuz $bootoptions
+        initrd (loop)/images/pxeboot/initrd.img
       }
       menuentry "Rescue a Fedora system" {
-        bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label rescue quiet"
-        linux (loop)/isolinux/vmlinuz $bootoptions
-        initrd (loop)/isolinux/initrd.img
+        bootoptions="iso-scan/filename=$iso_path inst.stage2=hd:LABEL=$cd_label inst.rescue quiet"
+        linux (loop)/images/pxeboot/vmlinuz $bootoptions
+        initrd (loop)/images/pxeboot/initrd.img
       }
-      menuentry "Run a memory test" {
-        bootoptions=""
-        linux16 (loop)/isolinux/memtest $bootoptions
-      }
+      #menuentry "Run a memory test" {
+      #  bootoptions=""
+      #  linux16 (loop)/isolinux/memtest $bootoptions
+      #}
     }
   fi
 done


### PR DESCRIPTION
Updating for current stable release (Fedora 39 as of this writing).
Commenting out the memtest menuentry because it seems no longer present within the ISO...