### PR TITLE
Update live-generic.cfg for Fedora

### DIFF
--- a/mbusb.d/fedora.d/live-generic.cfg
+++ b/mbusb.d/fedora.d/live-generic.cfg
@@ -3,27 +3,27 @@ for isofile in $isopath/Fedora-*-Live-*.iso; do
     regexp --set=isoname "$isopath/(.*)" "$isofile"
     submenu "$isoname ->" "$isofile" {
       iso_path="$2"
-      _loopback loop "$iso_path"
+      loopback loop "$iso_path"
       probe --label --set=cd_label (loop)
       menuentry "Start Fedora Live" {
-        bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image quiet"
-        linux (loop)/isolinux/vmlinuz $bootoptions
-        initrd (loop)/isolinux/initrd.img
+        bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image rhgb quiet"
+        linux (loop)/images/pxeboot/vmlinuz $bootoptions
+        initrd (loop)/images/pxeboot/initrd.img
       }
       menuentry "Start Fedora Live in basic graphics mode" {
-        bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image nomodeset quiet"
-        linux (loop)/isolinux/vmlinuz $bootoptions
-        initrd (loop)/isolinux/initrd.img
+        bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image nomodeset vga=791 rhgb quiet"
+        linux (loop)/images/pxeboot/vmlinuz $bootoptions
+        initrd (loop)/images/pxeboot/initrd.img
       }
       menuentry "Test this media & start Fedora Live" {
         bootoptions="iso-scan/filename=$iso_path root=live:CDLABEL=$cd_label rd.live.image rd.live.check quiet"
-        linux (loop)/isolinux/vmlinuz $bootoptions
-        initrd (loop)/isolinux/initrd.img
+        linux (loop)/images/pxeboot/vmlinuz $bootoptions
+        initrd (loop)/images/pxeboot/initrd.img
       }
-      menuentry "Run a memory test" {
-        bootoptions=""
-        linux16 (loop)/isolinux/memtest $bootoptions
-      }
+      #menuentry "Run a memory test" {
+      #  bootoptions=""
+      #  linux16 (loop)/isolinux/memtest $bootoptions
+      #}
     }
   fi
 done


### PR DESCRIPTION
Updating for current stable release (Fedora 39 as of this writing).
Commenting out the memtest menuentry because it seems no longer present within the ISO...